### PR TITLE
Update to 0.3.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -67,7 +62,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -75,6 +69,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.2" %}
+{% set version = "0.3.0" %}
 
 package:
   name: ctd
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: ctd-{{ version }}.tar.gz
-  url: https://github.com/pyoceans/python-ctd/releases/download/v{{ version }}/ctd-{{ version }}.tar.gz
-  sha256: f99ccda7d374a5f6707e2e8a947976c40bc0ebf42dbc788c1489f25c785314f4
+  url: https://pypi.io/packages/source/c/ctd/ctd-{{ version }}.tar.gz
+  sha256: c5144bf2200cd366fabacdd3c4dbe6cfd234a57beaf1aa221b159f5462bc4677
 
 build:
   number: 0
@@ -31,7 +31,8 @@ test:
 
 about:
   home: https://github.com/pyoceans/python-ctd
-  license: MIT
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
   summary: 'Tools to load hydrographic data formats as pandas DataFrames.'
 
 extra:


### PR DESCRIPTION
```
Version 0.3.0

* Changed license from `MIT` to BSD 3-Clause
* Fixed `gsw 3.1.1` compatibility issues
* Fixed reading pressure column from Sea Bird MicroCat SBE 37SM
* Fixed Python 2/3 encoding issues
* Improved CI test framework

This will be the past version using `pandas` b/c the `Panel` class is deprecated.
The next version will probably use `xarray` to store and serialized the CTD data.
```